### PR TITLE
Fix/map structure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,22 +1,24 @@
 [package]
-name = "dyson"
-version = "0.1.0"
 authors = ["hayas1 <h4ystack@gmail.com>"]
 description = "dynamic json parser"
 edition = "2021"
-rust-version = "1.61.0"
-repository = "https://github.com/hayas1/dyson"
 homepage = "https://hayas1.github.io/dyson/dyson"
 license-file = "LICENSE"
+name = "dyson"
 readme = "./README.md"
+repository = "https://github.com/hayas1/dyson"
+rust-version = "1.61.0"
+version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = "1.0"
+indexmap = "1.9.1"
 thiserror = "1.0"
-clap = { version = "3.2", features = ["derive"] }
+
 atty = "0.2"
+clap = {version = "3.2", features = ["derive"]}
 
 [dev-dependencies]
 tempfile = "3.3"

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ println!("{:?}", json["keyword"].array()); // ["RUST", "JSON", "PARSER"]
 // write json
 json.dump("path/to/write.json").expect("failed to write json");
 // {
-//     "version": 0.2,
-//     "notation": "json",
 //     "language": "ruby",
+//     "notation": "json",
+//     "version": 0.2,
 //     "keyword": [
 //         "RUST",
 //         "JSON",
@@ -83,13 +83,13 @@ SUBCOMMANDS:
     help       Print this message or the help of the given subcommand(s)
 ```
 #### format
-format output will be random...
+format output will be same json string.
 ```sh
 $ dyson format path/to/read.json
 {
-    "version": 0.1,
     "language": "rust",
     "notation": "json",
+    "version": 0.1,
     "keyword": [
         "rust",
         "json",
@@ -101,9 +101,9 @@ $ dyson format path/to/read.json
 ```sh
 $ cat path/to/read.json | dyson format
 {
+    "language": "rust",
     "notation": "json",
     "version": 0.1,
-    "language": "rust",
     "keyword": [
         "rust",
         "json",

--- a/src/ast/into.rs
+++ b/src/ast/into.rs
@@ -1,26 +1,26 @@
 use super::Value;
-use std::collections::HashMap;
+use indexmap::IndexMap;
 
-/// evaluate `Value` to corresponded object such as `HashMap`, `Vec`, `bool`, `str`, `i64`, or `f64`.
+/// evaluate `Value` to corresponded object such as `IndexMap`, `Vec`, `bool`, `str`, `i64`, or `f64`.
 /// # panics
 /// call different type evaluate method cause panic.
 /// for example, if call [`Value::object`] to [`Value::Array`], it will panic.
 /// if want to get `None` instead of panic, use `get_` prefixed methods.
 impl Value {
-    pub fn get_object(&self) -> Option<&HashMap<String, Value>> {
+    pub fn get_object(&self) -> Option<&IndexMap<String, Value>> {
         match self {
             Value::Object(m) => Some(m),
             _ => None,
         }
     }
-    pub fn get_mut_object(&mut self) -> Option<&mut HashMap<String, Value>> {
+    pub fn get_mut_object(&mut self) -> Option<&mut IndexMap<String, Value>> {
         match self {
             Value::Object(m) => Some(m),
             _ => None,
         }
     }
-    pub fn object(&self) -> &HashMap<String, Value> {
-        self.get_object().unwrap_or_else(|| panic!("only Object can convert into HashMap, but {}", self.node_type()))
+    pub fn object(&self) -> &IndexMap<String, Value> {
+        self.get_object().unwrap_or_else(|| panic!("only Object can convert into IndexMap, but {}", self.node_type()))
     }
 
     pub fn get_array(&self) -> Option<&Vec<Value>> {
@@ -155,19 +155,19 @@ impl Value {
     }
 }
 
-impl From<Value> for HashMap<String, Value> {
+impl From<Value> for IndexMap<String, Value> {
     fn from(val: Value) -> Self {
         match val {
             Value::Object(m) => m,
-            _ => panic!("only Object can convert into HashMap, but {}", val.node_type()),
+            _ => panic!("only Object can convert into IndexMap, but {}", val.node_type()),
         }
     }
 }
-impl<'a> From<&'a Value> for &'a HashMap<String, Value> {
+impl<'a> From<&'a Value> for &'a IndexMap<String, Value> {
     fn from(val: &'a Value) -> Self {
         match val {
             Value::Object(m) => m,
-            _ => panic!("only Object can convert into HashMap, but {}", val.node_type()),
+            _ => panic!("only Object can convert into IndexMap, but {}", val.node_type()),
         }
     }
 }
@@ -291,8 +291,8 @@ impl Value {
     }
 }
 
-impl From<HashMap<String, Value>> for Value {
-    fn from(m: HashMap<String, Value>) -> Self {
+impl From<IndexMap<String, Value>> for Value {
+    fn from(m: IndexMap<String, Value>) -> Self {
         Value::Object(m)
     }
 }

--- a/src/ast/io.rs
+++ b/src/ast/io.rs
@@ -248,4 +248,41 @@ mod tests {
         }();
         assert!(result.is_ok());
     }
+
+    #[test]
+    fn test_json_to_same_string() {
+        let json: RawJson = [
+            r#"{"#,
+            r#"    "language": "rust","#,
+            r#"    "notation": "json","#,
+            r#"    "version": 0.1,"#,
+            r#"    "keyword": ["rust", "json", "parser"],"#,
+            r#"    "dict": {"one": 1, "two": 2, "three": 3}"#,
+            r#"}"#,
+        ]
+        .into_iter()
+        .collect();
+        let ast_root = Value::parse(json).unwrap();
+        assert_eq!(ast_root.to_string(), ast_root.to_string());
+        assert_eq!(ast_root.to_string(), ast_root.to_string());
+        assert_eq!(ast_root.to_string(), ast_root.to_string());
+        assert_eq!(ast_root.to_string(), ast_root.to_string());
+        assert_eq!(ast_root.to_string(), ast_root.to_string());
+        assert_eq!(ast_root.to_string(), ast_root.to_string());
+        assert_eq!(ast_root.to_string(), ast_root.to_string());
+        assert_eq!(ast_root.to_string(), ast_root.to_string());
+        assert_eq!(ast_root.to_string(), ast_root.to_string());
+        assert_eq!(ast_root.to_string(), ast_root.to_string());
+        assert_eq!(ast_root.stringify(), ast_root.stringify());
+        assert_eq!(ast_root.stringify(), ast_root.stringify());
+        assert_eq!(ast_root.stringify(), ast_root.stringify());
+        assert_eq!(ast_root.stringify(), ast_root.stringify());
+        assert_eq!(ast_root.stringify(), ast_root.stringify());
+        assert_eq!(ast_root.stringify(), ast_root.stringify());
+        assert_eq!(ast_root.stringify(), ast_root.stringify());
+        assert_eq!(ast_root.stringify(), ast_root.stringify());
+        assert_eq!(ast_root.stringify(), ast_root.stringify());
+        assert_eq!(ast_root.stringify(), ast_root.stringify());
+        println!("{}", ast_root);
+    }
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -4,7 +4,7 @@ pub mod into;
 pub mod io;
 pub mod visit;
 
-use std::collections::HashMap;
+use indexmap::IndexMap;
 
 /// [`Value`] is ast node of json. see [Introducing JSON](https://www.json.org/json-en.html) also.
 /// # supports
@@ -54,7 +54,7 @@ use std::collections::HashMap;
 #[derive(PartialEq, Debug, Clone)]
 pub enum Value {
     /// correspond to object of json. object can be represented by `HashMap` in rust.
-    Object(HashMap<String, Value>),
+    Object(IndexMap<String, Value>),
 
     /// correspond to array of json. array can be represented by `Vec` in rust.
     Array(Vec<Value>),

--- a/src/ast/visit.rs
+++ b/src/ast/visit.rs
@@ -1,5 +1,3 @@
-use std::{collections::hash_map, slice};
-
 use super::Value;
 
 pub struct DfsVisitor<'a> {
@@ -7,8 +5,8 @@ pub struct DfsVisitor<'a> {
     first: Option<&'a Value>,
 }
 enum ValueIterator<'a> {
-    ObjectIterator(hash_map::Iter<'a, String, Value>),
-    ArrayIterator(slice::Iter<'a, Value>),
+    ObjectIterator(indexmap::map::Iter<'a, String, Value>),
+    ArrayIterator(std::slice::Iter<'a, Value>),
 }
 #[derive(Debug, PartialEq)]
 pub enum DfsEvent<'a> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,9 +43,9 @@
 //! // write json
 //! json.dump("path/to/write.json").expect("failed to write json");
 //! // {
-//! //     "version": 0.2,
-//! //     "notation": "json",
 //! //     "language": "ruby",
+//! //     "notation": "json",
+//! //     "version": 0.2,
 //! //     "keyword": [
 //! //         "RUST",
 //! //         "JSON",

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::{ast::Value, rawjson::RawJson};
 use anyhow::Context as _;
-use std::collections::HashMap;
+use indexmap::IndexMap;
 
 pub struct Parser<'a> {
     pub(crate) lexer: Lexer<'a>,
@@ -54,7 +54,7 @@ impl<'a> Parser<'a> {
     /// parse `object` of json. the following ebnf is not precise.<br>
     /// `object` := "{" { `string` ":" `value` \[ "," \] }  "}"
     pub fn parse_object(&mut self) -> anyhow::Result<Value> {
-        let mut object = HashMap::new();
+        let mut object = IndexMap::new();
         let (_, _left_brace) = self.lexer.lex_1_char::<_, SkipWs<true>>(MainToken::LeftBrace)?;
         while !self.lexer.is_next::<_, SkipWs<true>>(MainToken::RightBrace) {
             if self.lexer.is_next::<_, SkipWs<true>>(MainToken::Quotation) {
@@ -306,7 +306,7 @@ mod tests {
         let mut parser = Parser::new(&empty);
         let object = parser.parse_object();
         if let Value::Object(m) = object.unwrap() {
-            assert_eq!(m, HashMap::new());
+            assert_eq!(m, IndexMap::new());
         } else {
             unreachable!("\"{{}}\" must be parsed as empty object");
         }


### PR DESCRIPTION
# fix map order
use `indexmap` for `Object` structure.
same json will be converted into the same string.

# remark
`indexmap` keep insertion order, until remove operation.
its remove operation is swap remove, so removing will destruct insertion order.